### PR TITLE
Fix for long headways in real-time

### DIFF
--- a/SQL-scripts/ProcessRTEvent.sql
+++ b/SQL-scripts/ProcessRTEvent.sql
@@ -258,8 +258,8 @@ BEGIN
 					AND
 						(SELECT parent_station FROM gtfs.stops s WHERE e.stop_id = s.stop_id) = ps.parent_station
 				WHERE		
-					--	e.service_date = @service_date_process
-					--AND
+						e.service_date = @current_service_date
+					AND
 						e.stop_id NOT IN (SELECT stop_id FROM gtfs.route_direction_stop)
 
 			--Start processing departure events

--- a/SQL-scripts/ProcessRTEvent.sql
+++ b/SQL-scripts/ProcessRTEvent.sql
@@ -15,7 +15,7 @@ GO
 
 CREATE PROCEDURE dbo.ProcessRTEvent
 
---Script Version: Master - 1.1.1.0
+--Script Version: Master - 1.1.1.1
 
 --This procedure processes all the real-time events. It is executed by the process_rt_event trigger ON INSERT into the dbo.rt_event table.
 

--- a/SQL-scripts/ProcessRTEvent.sql
+++ b/SQL-scripts/ProcessRTEvent.sql
@@ -15,7 +15,7 @@ GO
 
 CREATE PROCEDURE dbo.ProcessRTEvent
 
---Script Version: Master - 1.1.0.0 - real-time-headway-fix - 2
+--Script Version: Master - 1.1.1.0
 
 --This procedure processes all the real-time events. It is executed by the process_rt_event trigger ON INSERT into the dbo.rt_event table.
 


### PR DESCRIPTION
Changes are:

- match on departure times for headways at terminals

- update platform stop ids to station stop ids
