### PR TITLE
Restrict data in API response to past 90 days

### DIFF
--- a/SQL-scripts/getDailyMetrics.sql
+++ b/SQL-scripts/getDailyMetrics.sql
@@ -16,7 +16,7 @@ GO
 
 CREATE PROCEDURE dbo.getDailyMetrics
 
---Script Version: Master - 1.1.0.0
+--Script Version: Master - 1.1.0.0 - API-restrict-days - 1
 
 --This stored procedure is called by the dailymetrics API call.  It selects daily metrics for a particular route (or all routes) and time period.
 
@@ -28,6 +28,8 @@ AS
 
 BEGIN
 	SET NOCOUNT ON;
+
+	DECLARE @limit_date DATE = DATEADD(DAY, -90, CONVERT(DATE,GETDATE())) 
 
 	DECLARE @metricstemp AS TABLE
 	(
@@ -64,7 +66,6 @@ BEGIN
 			FROM dbo.historical_metrics
 
 			WHERE
-
 					(
 						(SELECT COUNT(str_val) FROM @route_ids) = 0
 					OR 
@@ -76,7 +77,6 @@ BEGIN
 					service_date <= @to_date
 				AND 
 					route_id IN ('Red','Orange','Blue','Green-B','Green-C','Green-D','Green-E')
-
 
 	END --if a timespan is less than 31 days and routes are only subway/light rail, then do the processing, if not return empty set
 
@@ -90,6 +90,7 @@ BEGIN
 		,metric_result
 		,metric_result_trip
 	FROM @metricstemp
+	WHERE service_date > = @limit_date
 	ORDER BY
 		service_date,route_id,threshold_id,time_period_type
 

--- a/SQL-scripts/getDailyMetrics.sql
+++ b/SQL-scripts/getDailyMetrics.sql
@@ -16,7 +16,7 @@ GO
 
 CREATE PROCEDURE dbo.getDailyMetrics
 
---Script Version: Master - 1.1.0.0 - API-restrict-days - 1
+--Script Version: Master - 1.2.0.0
 
 --This stored procedure is called by the dailymetrics API call.  It selects daily metrics for a particular route (or all routes) and time period.
 

--- a/SQL-scripts/getDailyPredictionMetrics.sql
+++ b/SQL-scripts/getDailyPredictionMetrics.sql
@@ -16,7 +16,7 @@ GO
 
 CREATE PROCEDURE dbo.getDailyPredictionMetrics
 
---Script Version: Master - 1.1.0.0 - API-restrict-days - 1
+--Script Version: Master - 1.2.0.0
 
 --This stored procedure is called by the dailypredictionmetrics API call.  It selects daily prediction metrics for a particular route (or all routes) and time period.
 

--- a/SQL-scripts/getDailyPredictionMetrics.sql
+++ b/SQL-scripts/getDailyPredictionMetrics.sql
@@ -16,7 +16,7 @@ GO
 
 CREATE PROCEDURE dbo.getDailyPredictionMetrics
 
---Script Version: Master - 1.1.0.0
+--Script Version: Master - 1.1.0.0 - API-restrict-days - 1
 
 --This stored procedure is called by the dailypredictionmetrics API call.  It selects daily prediction metrics for a particular route (or all routes) and time period.
 
@@ -28,6 +28,8 @@ AS
 
 BEGIN
 	SET NOCOUNT ON;
+
+	DECLARE @limit_date DATE = DATEADD(DAY, -90, CONVERT(DATE,GETDATE()))
 
 	DECLARE @metricstemp AS TABLE
 	(
@@ -41,17 +43,11 @@ BEGIN
 
 	IF
 		(
-		(DATEDIFF(D,@from_date,@to_date) <= 31)
-		AND (
-		(
-			SELECT
-				COUNT(str_val)
-			FROM @route_ids
-			WHERE
-				str_val NOT IN ('Red','Orange','Blue','Green-B','Green-C','Green-D','Green-E', 'Mattapan')
+			(DATEDIFF(D,@from_date,@to_date) <= 31)
+		AND 
+			((SELECT COUNT(str_val) FROM @route_ids WHERE str_val NOT IN ('Red','Orange','Blue','Green-B','Green-C','Green-D','Green-E', 'Mattapan')) = 0)
 		)
-		= 0)
-		)
+
 	BEGIN --if a timespan is less than 31 days and routes are only subway/light rail, then do the processing, if not return empty set
 
 		INSERT INTO @metricstemp
@@ -66,25 +62,18 @@ BEGIN
 			FROM dbo.historical_prediction_metrics
 
 			WHERE
-
 				(
-					(
-						SELECT
-							COUNT(str_val)
-						FROM @route_ids
-					)
-					= 0
-					OR route_id IN
-					(
-						SELECT
-							str_val
-						FROM @route_ids
+						(SELECT COUNT(str_val) FROM @route_ids) = 0
+					OR 
+						route_id IN (SELECT str_val FROM @route_ids
 					)
 				)
-				AND service_date >= @from_date
-				AND service_date <= @to_date
-				AND route_id IN ('Red','Orange','Blue','Green-B','Green-C','Green-D','Green-E','Mattapan')
-
+				AND 
+					service_date >= @from_date
+				AND 
+					service_date <= @to_date
+				AND 
+					route_id IN ('Red','Orange','Blue','Green-B','Green-C','Green-D','Green-E','Mattapan')
 
 	END --if a timespan is less than 31 days and routes are only subway/light rail, then do the processing, if not return empty set
 
@@ -96,6 +85,7 @@ BEGIN
 		,threshold_type
 		,metric_result
 	FROM @metricstemp
+	WHERE service_date > = @limit_date
 	ORDER BY
 		service_date,route_id,threshold_id
 

--- a/SQL-scripts/getDwellTimes.sql
+++ b/SQL-scripts/getDwellTimes.sql
@@ -16,7 +16,7 @@ GO
 
 CREATE PROCEDURE dbo.getDwellTimes
 
---Script Version: Master - 1.1.0.0 - API-restrict-days - 1
+--Script Version: Master - 1.2.0.0
 
 --This Procedure is called by the dwelltimes API call. It selects dwell times for a particular stop (and optionally route + direction) and time period.
 

--- a/SQL-scripts/getDwellTimes.sql
+++ b/SQL-scripts/getDwellTimes.sql
@@ -16,7 +16,7 @@ GO
 
 CREATE PROCEDURE dbo.getDwellTimes
 
---Script Version: Master - 1.1.0.0
+--Script Version: Master - 1.1.0.0 - API-restrict-days - 1
 
 --This Procedure is called by the dwelltimes API call. It selects dwell times for a particular stop (and optionally route + direction) and time period.
 
@@ -33,9 +33,12 @@ AS
 BEGIN
 	SET NOCOUNT ON;
 
+	DECLARE @limit_date DATE = DATEADD(DAY, -90, CONVERT(DATE,GETDATE())) 
+
 	DECLARE @dwelltimestemp AS TABLE
 	(
-		route_id		VARCHAR(255)
+		service_date	DATE
+		,route_id		VARCHAR(255)
 		,direction_id	INT
 		,start_time		DATETIME
 		,end_time		DATETIME
@@ -48,7 +51,8 @@ BEGIN
 
 		INSERT INTO @dwelltimestemp
 			SELECT --selects dwell times from today, if the from_time and to_time are today
-				route_id
+				service_date
+				,route_id
 				,direction_id
 				,DATEADD(s,start_time_sec,service_date) AS start_time
 				,DATEADD(s,end_time_sec,service_date) AS end_time
@@ -68,7 +72,8 @@ BEGIN
 			UNION
 
 			SELECT --selects dwell times from other days in the past, if the from_time and to_time are not today
-				route_id
+				service_date
+				,route_id
 				,direction_id
 				,DATEADD(s,start_time_sec,service_date) AS start_time
 				,DATEADD(s,end_time_sec,service_date) AS end_time
@@ -98,7 +103,9 @@ BEGIN
 	ON
 		d.route_id = r.route_id
 	WHERE
-		r.route_type <> 2 --do not return results for Commuter Rail
+			r.route_type <> 2 --do not return results for Commuter Rail
+		AND
+			service_date >= @limit_date
 	ORDER BY end_time
 
 END

--- a/SQL-scripts/getEvents.sql
+++ b/SQL-scripts/getEvents.sql
@@ -16,7 +16,7 @@ GO
 
 CREATE PROCEDURE dbo.getEvents
 
---Script Version: Master - 1.1.0.0 - API-restrict-days - 1
+--Script Version: Master - 1.2.0.0
 
 --This stored procedure is called by the getEvents API call.  It selects events for a particular route, direction, stop and time period.
 	

--- a/SQL-scripts/getEvents.sql
+++ b/SQL-scripts/getEvents.sql
@@ -16,7 +16,7 @@ GO
 
 CREATE PROCEDURE dbo.getEvents
 
---Script Version: Master - 1.1.0.0
+--Script Version: Master - 1.1.0.0 - API-restrict-days - 1
 
 --This stored procedure is called by the getEvents API call.  It selects events for a particular route, direction, stop and time period.
 	
@@ -53,6 +53,8 @@ BEGIN
 
 	DECLARE @service_date_to DATE
 	SET @service_date_to = dbo.fnConvertDateTimeToServiceDate(@to_time)
+
+	DECLARE @limit_date DATE = DATEADD(DAY, -90, CONVERT(DATE,GETDATE())) 
 
 	IF (@service_date_from = @service_date_to) --only return results for one day
 
@@ -202,7 +204,9 @@ BEGIN
 	ON
 		e.route_id = r.route_id
 	WHERE
-		r.route_type <> 2 --do not return results for Commuter Rail
+			r.route_type <> 2 --do not return results for Commuter Rail
+		AND
+			service_date >= @limit_date
 	ORDER BY event_time
 
 END

--- a/SQL-scripts/getHeadwayTimes.sql
+++ b/SQL-scripts/getHeadwayTimes.sql
@@ -19,7 +19,7 @@ GO
 
 CREATE PROCEDURE dbo.getHeadwayTimes
 
---Script Version: Master - 1.1.0.0 - API-restrict-days - 1
+--Script Version: Master - 1.2.0.0
 
 --This Procedure is called by the headway API call. It selects headways  for a particular stop (and optionally to_stop or route + direction) and time period.
 

--- a/SQL-scripts/getHeadwayTimes.sql
+++ b/SQL-scripts/getHeadwayTimes.sql
@@ -19,7 +19,7 @@ GO
 
 CREATE PROCEDURE dbo.getHeadwayTimes
 
---Script Version: Master - 1.1.0.0
+--Script Version: Master - 1.1.0.0 - API-restrict-days - 1
 
 --This Procedure is called by the headway API call. It selects headways  for a particular stop (and optionally to_stop or route + direction) and time period.
 
@@ -37,9 +37,12 @@ AS
 BEGIN
 	SET NOCOUNT ON;
 
+	DECLARE @limit_date DATE = DATEADD(DAY, -90, CONVERT(DATE,GETDATE())) 
+
 	DECLARE @headwaytimestemp AS TABLE
 	(
-		route_id					VARCHAR(255)
+		service_date				DATE
+		,route_id					VARCHAR(255)
 		,prev_route_id				VARCHAR(255)
 		,direction_id				INT
 		,start_time					DATETIME
@@ -73,7 +76,8 @@ BEGIN
 					INSERT INTO @headwaytimestemp
 						
 						SELECT --selects headways from today, if the from_time and to_time are today
-							htt.route_id
+							htt.service_date
+							,htt.route_id
 							,htt.prev_route_id
 							,htt.direction_id
 							,DATEADD(s,htt.start_time_sec,htt.service_date) AS start_time
@@ -156,7 +160,8 @@ BEGIN
 					INSERT INTO @headwaytimestemp
 						
 						SELECT --selects headways from today, if the from_time and to_time are today
-							htt.route_id
+							htt.service_date
+							,htt.route_id
 							,htt.prev_route_id
 							,htt.direction_id
 							,DATEADD(s,htt.start_time_sec,htt.service_date) AS start_time
@@ -245,7 +250,8 @@ BEGIN
 					INSERT INTO @headwaytimestemp
 						
 						SELECT --selects headways from today, if the from_time and to_time are today
-							htt.route_id
+							htt.service_date
+							,htt.route_id
 							,htt.prev_route_id
 							,htt.direction_id
 							,DATEADD(s,htt.start_time_sec,htt.service_date) AS start_time
@@ -340,7 +346,8 @@ BEGIN
 					INSERT INTO @headwaytimestemp
 						
 						SELECT --selects headways from days in the past, if the from_time and to_time are not today
-							htt.route_id
+							htt.service_date
+							,htt.route_id
 							,htt.prev_route_id
 							,htt.direction_id
 							,DATEADD(s,htt.start_time_sec,htt.service_date) AS start_time
@@ -423,7 +430,8 @@ BEGIN
 					INSERT INTO @headwaytimestemp
 						
 						SELECT --selects headways from days in the past, if the from_time and to_time are not today
-							htt.route_id
+							htt.service_date
+							,htt.route_id
 							,htt.prev_route_id
 							,htt.direction_id
 							,DATEADD(s,htt.start_time_sec,htt.service_date) AS start_time
@@ -512,7 +520,8 @@ BEGIN
 					INSERT INTO @headwaytimestemp
 						
 						SELECT --selects headways from days in the past, if the from_time and to_time are not today
-							htt.route_id
+							htt.service_date
+							,htt.route_id
 							,htt.prev_route_id
 							,htt.direction_id
 							,DATEADD(s,htt.start_time_sec,htt.service_date) AS start_time
@@ -612,7 +621,9 @@ BEGIN
 	ON
 		h.route_id = r.route_id
 	WHERE
-		r.route_type <> 2 --do not return results for Commuter Rail
+			r.route_type <> 2 --do not return results for Commuter Rail
+		AND
+			service_date >= @limit_date
 	ORDER BY end_time
 
 END

--- a/SQL-scripts/getPredictionMetrics.sql
+++ b/SQL-scripts/getPredictionMetrics.sql
@@ -16,7 +16,7 @@ GO
 
 CREATE PROCEDURE dbo.getPredictionMetrics
 
---Script Version: Master - 1.1.0.0
+--Script Version: Master - 1.1.0.0 - API-restrict-days - 1
 
 --This stored procedure is called by the predictionmetrics API call.  It selects prediction metrics for a particular route(s), direction(s), and stop(s) and time period.
 
@@ -52,6 +52,8 @@ BEGIN
 
 	DECLARE @service_date_to DATE
 	SET @service_date_to = dbo.fnConvertDateTimeToServiceDate(@to_time)
+
+	DECLARE @limit_date DATE = DATEADD(DAY, -90, CONVERT(DATE,GETDATE()))
 
 	IF @service_date_from = @service_date_to --only return results for one day
 	
@@ -104,6 +106,7 @@ BEGIN
 		,total_predictions_in_bin
 		,metric_result
 	FROM @metricstemp
+	WHERE service_date > = @limit_date
 	ORDER BY
 		service_date
 		,route_id

--- a/SQL-scripts/getPredictionMetrics.sql
+++ b/SQL-scripts/getPredictionMetrics.sql
@@ -16,7 +16,7 @@ GO
 
 CREATE PROCEDURE dbo.getPredictionMetrics
 
---Script Version: Master - 1.1.0.0 - API-restrict-days - 1
+--Script Version: Master - 1.2.0.0
 
 --This stored procedure is called by the predictionmetrics API call.  It selects prediction metrics for a particular route(s), direction(s), and stop(s) and time period.
 

--- a/SQL-scripts/getTravelTimes.sql
+++ b/SQL-scripts/getTravelTimes.sql
@@ -20,7 +20,7 @@ GO
 
 CREATE PROCEDURE dbo.getTravelTimes
 
---Script Version: Master - 1.1.0.0 - API-restrict-days - 1
+--Script Version: Master - 1.2.0.0
 
 --This Procedure is called by the traveltimes API call. It selects travel times for a particular from_stop and to_stop pair (and optionally route)
 --and time period.

--- a/SQL-scripts/getTravelTimes.sql
+++ b/SQL-scripts/getTravelTimes.sql
@@ -20,14 +20,14 @@ GO
 
 CREATE PROCEDURE dbo.getTravelTimes
 
---Script Version: Master - 1.1.0.0
+--Script Version: Master - 1.1.0.0 - API-restrict-days - 1
 
 --This Procedure is called by the traveltimes API call. It selects travel times for a particular from_stop and to_stop pair (and optionally route)
 --and time period.
 
-	@from_stop_id VARCHAR(255)
-	,@to_stop_id VARCHAR(255)
-	,@from_time DATETIME
+	@from_stop_id VARCHAR(255) 
+	,@to_stop_id VARCHAR(255) 
+	,@from_time DATETIME 
 	,@to_time DATETIME
 	,@route_id VARCHAR(255)
 
@@ -37,9 +37,12 @@ AS
 BEGIN
 	SET NOCOUNT ON;
 
+	DECLARE @limit_date DATE = DATEADD(DAY, -90, CONVERT(DATE,GETDATE())) 
+
 	DECLARE @traveltimestemp AS TABLE
 	(
-		route_id					VARCHAR(255)
+		service_date				DATE
+		,route_id					VARCHAR(255)
 		,direction_id				INT
 		,start_time					DATETIME
 		,end_time					DATETIME
@@ -56,7 +59,8 @@ BEGIN
 
 		INSERT INTO @traveltimestemp
 			SELECT --selects travel times from today, if the from_time and to_time are today
-				htt.route_id
+				htt.service_date
+				,htt.route_id
 				,htt.direction_id
 				,DATEADD(s,htt.start_time_sec,htt.service_date) AS start_time
 				,DATEADD(s,htt.end_time_sec,htt.service_date) AS end_time
@@ -137,7 +141,8 @@ BEGIN
 			UNION
 
 			SELECT --selects travel times from days in the past, if the from_time and to_time are not today
-				htt.route_id
+				htt.service_date
+				,htt.route_id
 				,htt.direction_id
 				,DATEADD(s,htt.start_time_sec,htt.service_date) AS start_time
 				,DATEADD(s,htt.end_time_sec,htt.service_date) AS end_time
@@ -222,7 +227,8 @@ BEGIN
 			UNION
 
 			SELECT --selects travel times from today, if the from_time and to_time are today
-				htt.route_id
+				htt.service_date
+				,htt.route_id
 				,htt.direction_id
 				,DATEADD(s,htt.start_time_sec,htt.service_date) AS start_time
 				,DATEADD(s,htt.end_time_sec,htt.service_date) AS end_time
@@ -304,7 +310,8 @@ BEGIN
 			--commuter rail thresholds for travel time
 
 			SELECT --selects travel times from days in the past, if the from_time and to_time are not today
-				htt.route_id
+				htt.service_date
+				,htt.route_id
 				,htt.direction_id
 				,DATEADD(s,htt.start_time_sec,htt.service_date) AS start_time
 				,DATEADD(s,htt.end_time_sec,htt.service_date) AS end_time
@@ -385,7 +392,8 @@ BEGIN
 			UNION
 
 			SELECT --selects travel times from today, if the from_time and to_time are today
-				htt.route_id
+				htt.service_date
+				,htt.route_id
 				,htt.direction_id
 				,DATEADD(s,htt.start_time_sec,htt.service_date) AS start_time
 				,DATEADD(s,htt.end_time_sec,htt.service_date) AS end_time
@@ -470,7 +478,9 @@ BEGIN
 	ON
 		t.route_id = r.route_id
 	WHERE
-		r.route_type <> 2 --do not return results for Commuter Rail
+			r.route_type <> 2 --do not return results for Commuter Rail
+		AND
+			service_date >= @limit_date
 	ORDER BY end_time 
 
 END


### PR DESCRIPTION
Changes made to these stored procedures: getDailyMetrics, getDailyPredictionMetrics, getDwellTimes, getEvents, getHeadwayTimes, getPredictionMetrics, getTravelTimes